### PR TITLE
Switch to MIT License

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,20 @@
+Copyright (c) 2012 Linden Research, Inc. 
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal in the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions:
+
+The above copyright notice and this permission notice shall be
+included in all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION
+WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/leap/__init__.py
+++ b/leap/__init__.py
@@ -1,8 +1,5 @@
-"""\
-@file   leap.py
-@author Nat Goodspeed
-@date   2012-03-14
-@brief  Python implementation of LEAP (LLSD Event API Plugin) protocol
+"""
+Python implementation of LEAP (LLSD Event API Plugin) protocol
 
 This module supports Python scripts used as viewer LEAP plugins. Every such
 script must be able to send to stdout, and receive on stdin, LEAP protocol.
@@ -37,10 +34,6 @@ where:
 In addition to the above, each line written to stderr is logged to the
 viewer's log -- but our consumer script needs no special support from us to
 write to stderr.
-
-$LicenseInfo:firstyear=2012&license=viewerlgpl$
-Copyright (c) 2012, Linden Research, Inc.
-$/LicenseInfo$
 """
 
 import errno

--- a/leap/examples/helloworld.py
+++ b/leap/examples/helloworld.py
@@ -1,28 +1,6 @@
 #!/usr/bin/env python3
-"""\
-@file helloworld.py
-@brief simple LEAP script which will send a message to SecondLifeViewer every second
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
- 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
+"""
+Simple LEAP script which will send a message to SecondLifeViewer every second
 """
 
 # example init input:

--- a/puppetry/__init__.py
+++ b/puppetry/__init__.py
@@ -1,31 +1,7 @@
 #!/usr/bin/env python3
-"""\
-@file puppetry.py
-@brief simple framework for sending puppetry data to SL viewer
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
 """
+Simple framework for sending puppetry data to SL viewer
 
-'''
 This module uses the LEAP framework for sending messages to the SL viewer.
 
 Tell the viewer to launch some script.py with the following option:
@@ -58,11 +34,7 @@ leap.py module is waiting for the initial message from the viewer.  To unblock
 the system paste the following string into the script's stdin:
 
 119:{'data':{'command':'18ce5015-b651-1d2e-2470-0de841fd3635','features':{}},'pump':'54481a53-c41f-4fc2-606e-516daed03636'}
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Copyright (c) 2022, Linden Research, Inc.
-$/LicenseInfo$
-'''
+"""
 
 import datetime
 import logging

--- a/puppetry/examples/arm_wave.py
+++ b/puppetry/examples/arm_wave.py
@@ -1,28 +1,6 @@
 #!/usr/bin/env python3
-"""\
-@file arm_wave.py
-@brief simple LEAP script to move the avatar
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
- 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
+"""
+Simple LEAP script to move the avatar
 """
 
 '''

--- a/puppetry/examples/head_and_arms_move.py
+++ b/puppetry/examples/head_and_arms_move.py
@@ -1,31 +1,7 @@
 #!/usr/bin/env python3
-"""\
-@file head_and_arms_move.py
-@brief simple LEAP script to move the avatar
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
- 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
 """
+simple LEAP script to move the avatar
 
-'''
 head_and_arms_move.py -- use IK to animate the head and arms
 
 Run this script via viewer menu...
@@ -49,7 +25,7 @@ string into the script's stdin:
 
 Also, for more readable text with newlines between messages
 uncomment the print("") line in the main loop below.
-'''
+"""
 
 import logging
 import math

--- a/puppetry/examples/head_nod.py
+++ b/puppetry/examples/head_nod.py
@@ -1,31 +1,7 @@
 #!/usr/bin/env python3
-"""\
-@file head_nod.py
-@brief simple LEAP script to move the avatar's head up and down, and back and forth
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
- 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
 """
+simple LEAP script to move the avatar's head up and down, and back and forth
 
-'''
 head_nod.py -- use Puppetry to update head's local orientation
 
 Run this script via viewer menu...
@@ -49,7 +25,7 @@ string into the script's stdin:
 
 Also, for more readable text with newlines between messages
 uncomment the print("") line in the main loop below.
-'''
+"""
 
 import math
 import time

--- a/puppetry/examples/minimum_example.py
+++ b/puppetry/examples/minimum_example.py
@@ -5,7 +5,7 @@ import time
 import eventlet
 import puppetry
 
-'''
+"""
 Note: When you debug this script at the command line it will block
 because the leap.py framework is waiting for the initial message
 from the viewer.  To unblock the system paste the following
@@ -15,7 +15,7 @@ string into the script's stdin:
 
 Also when debugging, for more readable text with newlines between
 messages uncomment the print("") line in the main loop below.
-'''
+"""
 
 update_period = 0.1
 t0 = time.monotonic()

--- a/puppetry/examples/mouth_move.py
+++ b/puppetry/examples/mouth_move.py
@@ -1,32 +1,6 @@
 #!/usr/bin/env python3
-"""\
-@file mouth_move.py
-@brief simple LEAP script to move the avatar's mouth
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
- 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
 """
-
-'''
-mouth_move.py -- use puppetry to animate the mouth
+simple LEAP script to move the avatar's mouth
 
 Run this script via viewer menu...
     Advanced --> Puppetry --> Launch LEAP plug-in...
@@ -49,7 +23,7 @@ string into the script's stdin:
 
 Also, for more readable text with newlines between messages
 uncomment the print("") line in the main loop below.
-'''
+"""
 
 import math
 import time

--- a/puppetry/examples/puppet_poser.py
+++ b/puppetry/examples/puppet_poser.py
@@ -1,30 +1,7 @@
 #!/usr/bin/env python3
-"""\
-@file puppet_poser.py
-@brief Simple LEAP script to read a data file and send puppetry data.
+"""
+Simple LEAP script to read a data file and send puppetry data.
 The file is re-read every cycle, so can be live edited to see changes
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
-
 
 This script uses the LEAP framework for sending messages to the viewer.
 Tell the viewer to launch it with the following option:
@@ -54,7 +31,6 @@ string into the script's stdin:
 
 Also, for more readable text with newlines between messages
 uncomment the print("") line in the main loop below.
-
 """
 
 import copy

--- a/puppetry/util/playback.py
+++ b/puppetry/util/playback.py
@@ -1,31 +1,7 @@
 #!/usr/bin/env python3
-"""\
-@file playback.py
-@brief simple LEAP script to read a data file and move the avatar
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
- 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
 """
+simple LEAP script to read a data file and move the avatar
 
-'''
 This script uses the LEAP framework for sending messages to the viewer that 
 are read from a file.
 
@@ -51,7 +27,7 @@ as 'puppet_data.txt' next to your viewer executable
 {'mHead': {'rot': [-0.07448343932628632, 0.06885180622339249, -0.035997889935970306]}, 'mWristLeft': {'pos': [0.05, 0.16729896764942478, 0.5361882011149134]}, 'mHandThumb3Left': {'pos': [0.06574690041785626, 0.12442234070665525, 0.5685525689166656]}, 'mHandIndex3Left': {'pos': [0.06662216794813625, 0.14029842110667906, 0.6212556577420765]}, 'mHandMiddle3Left': {'pos': [0.06620718293644166, 0.15229872926471846, 0.6300273446697175]}, 'mHandRing3Left': {'pos': [0.0670738089351241, 0.1642334542108759, 0.6287173451620537]}, 'mHandPinky3Left': {'pos': [0.06639558466617584, 0.18190129982428496, 0.6160302439715732]}, 'command': 'move', 'time': '2022-05-06 17:23:57.888231+00:00'}
 
 There seems to be a bug ? where only sending the same line over and over does not position correctly, but alternating between these two data sets works fine.
-'''
+"""
 
 import datetime
 import logging

--- a/puppetry/webcam/camera.py
+++ b/puppetry/webcam/camera.py
@@ -1,29 +1,3 @@
-"""\
-@file camera.py
-@brief
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
-"""
-
 import numpy as np
 import cv2
 

--- a/puppetry/webcam/display.py
+++ b/puppetry/webcam/display.py
@@ -1,29 +1,3 @@
-"""\
-@file display.py
-@brief
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
-"""
-
 import cv2
 import numpy as np
 import time

--- a/puppetry/webcam/head_webcam.py
+++ b/puppetry/webcam/head_webcam.py
@@ -1,30 +1,4 @@
-"""\
-@file head_webcam.py
-@brief 
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
- 
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
 """
-
-'''
 This script uses the LEAP framework for sending messages to the viewer.
 Tell the viewer to launch it with the following option:
     --leap "python /path/to/this/script/this_script.py"
@@ -51,8 +25,8 @@ string into the script's stdin:
 
 Also, for more readable text with newlines between messages
 uncomment the print("") line in the main loop below.
+"""
 
-'''
 
 import time
 import numpy as np

--- a/puppetry/webcam/pconsts.py
+++ b/puppetry/webcam/pconsts.py
@@ -1,29 +1,3 @@
-"""\
-@file pconsts.py
-@brief
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
-"""
-
 import numpy as np
 
 class Model:

--- a/puppetry/webcam/plot.py
+++ b/puppetry/webcam/plot.py
@@ -1,28 +1,3 @@
-"""\
-@file plot.py
-@brief
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
-"""
 from mpl_toolkits.mplot3d import Axes3D
 import matplotlib.pyplot as plot
 

--- a/puppetry/webcam/putils.py
+++ b/puppetry/webcam/putils.py
@@ -1,32 +1,6 @@
-"""\
-@file puppet_utils.py
-@brief
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
 """
-
-'''
 utility functions
-'''
+"""
 
 import numpy as np
 import cv2

--- a/puppetry/webcam/webcam_puppetry.py
+++ b/puppetry/webcam/webcam_puppetry.py
@@ -1,31 +1,5 @@
 #!/usr/bin/env python3
-"""\
-@file webacam_puppetry.py
-@brief
-
-$LicenseInfo:firstyear=2022&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022, Linden Research, Inc.
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
 """
-
-'''
 This script uses the LEAP framework for sending messages to the viewer.
 Tell the viewer to launch it with the following option:
     --leap "python /path/to/this/script/this_script.py"
@@ -50,10 +24,8 @@ string into the script's stdin:
 
 119:{'data':{'command':'18ce5015-b651-1d2e-2470-0de841fd3635', \
      'features':{}},'pump':'54481a53-c41f-4fc2-606e-516daed03636'}
-'''
 
-#Overview
-'''
+# Overview
 webcam_puppetry is an example of using LEAP to control the avatar in the Second 
 Life viewer via live feed from a webcam processed through OpenCV 
 (https://opencv.org) and Mediapipe (https://google.github.io/mediapipe/)
@@ -71,7 +43,7 @@ pose hands and face
 
 Avatar position and rotation information is extracted from the mediapipe data
 and sent to the viewer via LEAP
-'''
+"""
 
 import argparse
 import cv2

--- a/puppetry/webcam/webcam_test.py
+++ b/puppetry/webcam/webcam_test.py
@@ -1,28 +1,6 @@
 #!/usr/bin/env python3
-"""\
-@file webcam_test.py 
+"""
 Stripped down webcam access for testing
-
-$LicenseInfo:firstyear=2010&license=viewerlgpl$
-Second Life Viewer Source Code
-Copyright (C) 2022-2022, Linden Research, Inc.
-
-This library is free software; you can redistribute it and/or
-modify it under the terms of the GNU Lesser General Public
-License as published by the Free Software Foundation;
-version 2.1 of the License only.
-
-This library is distributed in the hope that it will be useful,
-but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
-Lesser General Public License for more details.
-
-You should have received a copy of the GNU Lesser General Public
-License along with this library; if not, write to the Free Software
-Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
-
-Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
-$/LicenseInfo$
 """
 
 # This is a testing program for poking at the system and finding cameras.   It is not 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [metadata]
 name = leap
 version = 0.0.1
-license = LGPL
+license = MIT
 
 [options]
 packages =


### PR DESCRIPTION
Switch to the more permissive MIT license.

Adds a root-level LICENSE, as per common practice, and removes unneeded per-file license headers. The header-use policy has been signed-off on by Linden legal and conforms to our [style guide on MIT licensed python code](https://wiki.secondlife.com/wiki/Coding_standard#MIT_Licensed_Code).