### PR TITLE
Tweak Puppetry API of 

### DIFF
--- a/puppetry/__init__.py
+++ b/puppetry/__init__.py
@@ -167,7 +167,7 @@ def sendGet(data):
             _logger.info(f"malformed 'get' data={data}")
             return
         if data_out:
-            msg = { 'command':'get', 'get':data_out}
+            msg = { 'command':'get', 'data':data_out}
             msg.setdefault('reqid', get_next_request_id())
             _sendLeapRequest(msg)
 
@@ -177,7 +177,7 @@ def sendSet(data):
     """
     if _running:
         if isinstance(data, dict):
-            msg = { 'command':'set', 'set':data }
+            msg = { 'command':'set', 'data':data }
             msg.setdefault('reqid', get_next_request_id())
             _sendLeapRequest(msg)
         else:


### PR DESCRIPTION
It used to be the case that the **set** and **get** commands would use a "verb" key that matched their command:

`{"command":"set,"set":{...}}` and `{"command":"get,"get":[]}`

But they are being switched to both use a **data** key instead: `{"command":"set,"data":{...}}`.