### PR TITLE
Cleanup example documentation, add example that moves pelvis

### DIFF
--- a/puppetry/__init__.py
+++ b/puppetry/__init__.py
@@ -14,26 +14,35 @@ The viewer will start the script in a side process and will send messages
 to the process's stdin while receiving messages the script writes to its stdout.
 
 The messages have the form:
-num_bytes:{pump="puppetry",data='{"joint_name":{"param_name":[r1.23,r4.56,r7.89]}, ...}"'}
+num_bytes:{'pump':'puppetry',
+           'data':{'command':'set',
+                   'data':{'inverse_kinematics':{'mWristLeft':{'p':[r0.3,r0.5,r0.623],'r':[r0.5,r-0.5,r-0.5]},
+                                                 'mWristRight':{'p':[r0.3,r-0.5,r0.63],'r':[r-0.5,r-0.5,r0.5]}},
+                   'joint_state':{'mPelvis':{'p':[r0.0,r0.0171,r0.07]}}},
+           'reqid':i1,
+           'reply':!}}
 
 Where:
-
     num_byes = number of characters following the first colon.
 
+    pump = 'puppetry'
+
+    data = {'command': 'set'|'get', 'data': {}}
+
+    set data = {'inverse_kinematics':{'joint_name':{'position':[x,y,z], 'rotation':[qx,qy,qz], 'scale':[x,y,z]}},
+                'joint_state':{'joint_name':{'position':[x,y,z], 'rotation':[qx,qy,qz], 'scale':[x,y,z]}}}
+
+        alternatively can use terse format: 'i' instead of 'inverse_kinematics' and 'j' instead of 'joint_state'
+
     joint_name = string recognized by LLVOAvatar::getJoint(const std::string&),
-        e.g. something like: "mWristLeft"
+        e.g. something like: 'mWristLeft'
 
-    param_name = "local_rot" | "rot" | "pos" | "scale"
+    joint parameter name = 'position', 'rotation', or 'scale'
+        alternatively can use terse format: 'p', 'r', or 's'
 
-    param_name's value = LLSD array of three floats (e.g. [x,y,z])
+    joint parameter value = array of three floats [x, y, z]
 
-Multiple joints can be combined into the same LLSD formatted string.
-
-When you test a LEAP script at the command line it will block because the
-leap.py module is waiting for the initial message from the viewer.  To unblock
-the system paste the following string into the script's stdin:
-
-119:{'data':{'command':'18ce5015-b651-1d2e-2470-0de841fd3635','features':{}},'pump':'54481a53-c41f-4fc2-606e-516daed03636'}
+    The 'reqid' and 'reply' fields are added automatically by the LEAP module.
 """
 
 import datetime

--- a/puppetry/examples/arm_wave.py
+++ b/puppetry/examples/arm_wave.py
@@ -8,25 +8,27 @@ arm_wave.py -- use IK to animate the arm like it is waving hello/goodbye
 
 Run this script via viewer menu...
     Advanced --> Puppetry --> Launch LEAP plug-in...
+
 This script uses the LEAP framework for sending messages to the viewer.
-The joint data is a dictionary with the following format:
-    data={"joint_name":{"type":[1.23,4.56,7.89]}, ...}
+
+Typically you just want to send a "set" command:
+    puppetry.sendSet(data)
+
+The 'set' data is a dictionary with the following format:
+    data={"inverse_kinematics":{"joint_name":{"type":[1.23,4.56,7.89] ,...} ,...},
+          "joint_state":{"joint_name":{"type":[1.23,4.56,7.89] ,...} ,...}}
 Where:
-    joint_name = string recognized by LLVOAvatar::getJoint(const std::string&),
+    'inverse_kinematics' for specifying avatar-frame target transforms
+    'joint_state' for specifying parent-frame joint transforms
+        alternatively can use terse format: 'i' instead of 'inverse_kinematics' and 'j' instead of 'joint_state'
+
+    'joint_name' = string recognized by LLVOAvatar::getJoint(const std::string&),
         e.g. something like: "mWristLeft"
-    type = "rot" | "pos" | "scale"
+
+    'type' = "rotation" | "position" | "scale"
+        alternatively can use terse format: 'r', 'p', and 's'
+
     type's value = array of three floats (e.g. [x,y,z])
-Multiple joints can be combined into the same dictionary.
-
-Note: When you test this script at the command line it will block
-because the leap.py framework is waiting for the initial message
-from the viewer.  To unblock the system paste the following
-string into the script's stdin:
-
-119:{'data':{'command':'18ce5015-b651-1d2e-2470-0de841fd3635','features':{}},'pump':'54481a53-c41f-4fc2-606e-516daed03636'}
-
-Also, for more readable text with newlines between messages
-uncomment the print("") line in the main loop below.
 '''
 
 import logging
@@ -109,9 +111,9 @@ def computeData(time_step):
     # in this case it is the elbow whose 'end' is also the 'tip' of the wrist
     if arm == 'right':
         wrist_tip.y = - wrist_tip.y
-        data = { 'mElbowRight':{'pos':[wrist_tip.x, wrist_tip.y, wrist_tip.z]} }
+        data = { 'mElbowRight':{'p':[wrist_tip.x, wrist_tip.y, wrist_tip.z]} }
     else:
-        data = { 'mElbowLeft':{'pos':[wrist_tip.x, wrist_tip.y, wrist_tip.z]} }
+        data = { 'mElbowLeft':{'p':[wrist_tip.x, wrist_tip.y, wrist_tip.z]} }
     return data
 
 def spin():

--- a/puppetry/examples/arms_and_pelvis.py
+++ b/puppetry/examples/arms_and_pelvis.py
@@ -6,7 +6,7 @@
 $LicenseInfo:firstyear=2022&license=viewerlgpl$
 Second Life Viewer Source Code
 Copyright (C) 2022, Linden Research, Inc.
- 
+
 This library is free software; you can redistribute it and/or
 modify it under the terms of the GNU Lesser General Public
 License as published by the Free Software Foundation;
@@ -59,6 +59,7 @@ import time
 
 import eventlet
 import glm
+
 import puppetry
 
 # The avatar's coordinate frame:

--- a/puppetry/examples/arms_and_pelvis.py
+++ b/puppetry/examples/arms_and_pelvis.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""\
+@file arms_and_pelvis.py
+@brief simple LEAP script to animate the head and arms
+
+$LicenseInfo:firstyear=2022&license=viewerlgpl$
+Second Life Viewer Source Code
+Copyright (C) 2022, Linden Research, Inc.
+ 
+This library is free software; you can redistribute it and/or
+modify it under the terms of the GNU Lesser General Public
+License as published by the Free Software Foundation;
+version 2.1 of the License only.
+
+This library is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this library; if not, write to the Free Software
+Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301  USA
+
+Linden Research, Inc., 945 Battery Street, San Francisco, CA  94111  USA
+$/LicenseInfo$
+"""
+
+'''
+
+Run this script via viewer menu...
+    Advanced --> Puppetry --> Launch LEAP plug-in...
+
+This script uses the LEAP framework for sending messages to the viewer.
+
+Typically you just want to send a "set" command:
+    puppetry.sendSet(data)
+
+The 'set' data is a dictionary with the following format:
+    data={"inverse_kinematics":{"joint_name":{"type":[1.23,4.56,7.89] ,...} ,...},
+          "joint_state":{"joint_name":{"type":[1.23,4.56,7.89] ,...} ,...}}
+Where:
+    'inverse_kinematics' for specifying avatar-frame target transforms
+    'joint_state' for specifying parent-frame joint transforms
+        alternatively can use terse format: 'i' instead of 'inverse_kinematics' and 'j' instead of 'joint_state'
+
+    'joint_name' = string recognized by LLVOAvatar::getJoint(const std::string&),
+        e.g. something like: "mWristLeft"
+
+    'type' = "rotation" | "position" | "scale"
+        alternatively can use terse format: 'r', 'p', and 's'
+
+    type's value = array of three floats (e.g. [x,y,z])
+'''
+
+import logging
+import math
+import sys
+import time
+
+import eventlet
+import glm
+import puppetry
+
+# The avatar's coordinate frame:
+#             ___
+#            /o o\
+#            \___/
+#              |
+#  R o--+--+-+ | +-+--+--o L
+#              +
+#              |
+#              +         z
+#              |         |
+#            +-@-+       @--y
+#            |   |      /
+#            +   +     x
+#            |   |
+#            |   |
+#           /   /
+#
+# Puppetry expects position data to be in the normalized pelvis-relative frame
+# where 2.0 is the effective "arm span" of the avatar (e.g. the distance from
+# the "end" of one wrist bone to the other).
+#
+# In this space the approximate pelvis-relative positions of significant Joint
+# ends are as follows:
+#
+# end_of_head = [ -0.0323109, 0, 0.963779 ]
+# tip_of_chest = [ -0.020593, 0, 0.400766 ]
+# end_of_shoulder_left = [ -0.0497143, 0.610328, 0.629576 ]
+# end_of_elbow_left = [ -0.0497143, 0.967967, 0.629576 ]
+# end_of_wrist_left = [ -0.0497143, 1, 0.629576 ]
+# end_of_shoulder_right = [ -0.0497143, -0.610328, 0.629576 ]
+# end_of_elbow_right = [ -0.0497143, -0.967967, 0.629576 ]
+# end_of_wrist_right = [ -0.0497143, -1, 0.629576 ]
+
+orbit_radius = 0.0
+orbit_period = 8.0
+wave_speed = 2.0 * math.pi / orbit_period
+
+update_period = 0.1
+
+WRIST_X = 0.3
+WRIST_Y = 1.0
+WRIST_Z = 0.63
+
+HEAD_X = -0.0323
+HEAD_Y = 0.0
+HEAD_Z = 0.964
+
+# we will move each arm in a circle:
+# compute circle center, axis,
+# and planar components (up and in)
+head = glm.vec3(HEAD_X, HEAD_Y, HEAD_Z)
+neck = glm.vec3(0.0, 0.0, WRIST_Z)
+up_axis = glm.vec3(0.0, 0.0, 1.0)
+
+# pull the circle closer to the body a little bit
+left_center = glm.vec3(WRIST_X, 0.5 * WRIST_Y, 1.0 * WRIST_Z)
+left_axis = glm.normalize(left_center - neck)
+left_vertical = glm.normalize(glm.cross(left_axis, glm.cross(up_axis, left_axis)))
+left_horizontal = glm.normalize(glm.cross(left_axis, left_vertical))
+
+right_center = glm.vec3(WRIST_X, -0.5 * WRIST_Y, 1.0 * WRIST_Z)
+right_axis = glm.normalize(right_center - neck)
+right_vertical = glm.normalize(glm.cross(right_axis, glm.cross(up_axis, right_axis)))
+right_horizontal = glm.normalize(glm.cross(right_vertical, right_axis))
+
+
+t0 = time.monotonic()
+t = 0.0
+
+def computeData(time_step):
+    global t
+    t += time_step
+    # cycle t by orbit_period
+    # to avoid floating point error after running several days
+    if t > orbit_period or t < -orbit_period:
+        t -= int(t / orbit_period) * orbit_period
+
+    # compute the sinusoidal components
+    theta = t * wave_speed
+    s = math.sin(theta)
+    c = math.cos(theta)
+
+    # compute the circle positions
+    left = left_center + (orbit_radius * s) * left_vertical + (orbit_radius * c) * left_horizontal
+    left = left_center
+
+    # compute an avatar-frame orientation of the left hand
+    # to bring palm forward, fingers up
+    angle = math.pi / 4.0
+    s_angle = math.sin(angle)
+    c_angle = math.cos(angle)
+    q_y = glm.quat(s_angle, c_angle, 0.0, 0.0)
+    q_z = glm.quat(s_angle, 0.0, 0.0, -c_angle)
+    left_q = q_z * q_y
+
+    # similarly for right hand
+    q_y = glm.quat(s_angle, -c_angle, 0.0, 0.0)
+    q_z = glm.quat(s_angle, 0.0, 0.0, c_angle)
+    right_q = q_z * q_y
+
+    # Note: want right to be out of phase by pi, hence negate components
+    right = right_center - (orbit_radius * s) * right_vertical - (orbit_radius * c) * right_horizontal
+    right = right_center
+
+    pelvis_orbit_radius = 0.2
+    left_direction = glm.vec3(0.0, 1.0, 0.0)
+
+    # custom vertical adjustment to keep feet above ground
+    up_direction = glm.vec3(0.0, 0.0, 1.0)
+
+    #pelvis_orbit = (pelvis_orbit_radius * s) * left_direction + 0.07 * up_direction
+    pelvis_orbit = (pelvis_orbit_radius * s) * left_direction
+
+    # assemble the message
+    # Note: we're using kinematics to place the right and left hands in the avatar-frame
+    # and we're slamming the pelvis position in its parent-frame (however the parent-frame
+    # of the pelvis is the avatar-frame)
+    #
+    data = {
+        'inverse_kinematics': {
+            'mWristLeft':{'p':[left.x, left.y, left.z],'r':puppetry.packedQuaternion(left_q)},
+            'mWristRight':{'p':[right.x, right.y, right.z],'r':puppetry.packedQuaternion(right_q)} },
+        'joint_state': {
+            'mPelvis':{'p':[pelvis_orbit.x, pelvis_orbit.y, pelvis_orbit.z]}}
+        }
+    return data
+
+def spin():
+    t0 = time.monotonic()
+    delta_time = update_period
+    while puppetry.isRunning():
+        # sleep to yield to other eventlet coroutines
+        eventlet.sleep(max(0.0, 2 * update_period - delta_time))
+        t1 = time.monotonic()
+        delta_time = t1 - t0
+        t0 = t1
+        data = computeData(delta_time)
+        puppetry.sendSet(data)
+        #print("") # uncomment this when debugging at command-line
+
+puppetry.setLogLevel(logging.DEBUG)
+puppetry.start()
+
+# spin the animation
+spinner = eventlet.spawn(spin)
+
+# loop the UI until puppetry is stopped
+while puppetry.isRunning():
+    eventlet.sleep(0.2)
+
+# cleanup
+spinner.wait()
+

--- a/puppetry/examples/arms_and_pelvis.py
+++ b/puppetry/examples/arms_and_pelvis.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 """\
 @file arms_and_pelvis.py
-@brief simple LEAP script to animate the head and arms
+@brief simple LEAP script to demonstraint movable pelvis
 
 $LicenseInfo:firstyear=2022&license=viewerlgpl$
 Second Life Viewer Source Code

--- a/puppetry/examples/head_and_arms_move.py
+++ b/puppetry/examples/head_and_arms_move.py
@@ -6,25 +6,27 @@ head_and_arms_move.py -- use IK to animate the head and arms
 
 Run this script via viewer menu...
     Advanced --> Puppetry --> Launch LEAP plug-in...
+
 This script uses the LEAP framework for sending messages to the viewer.
-The joint data is a dictionary with the following format:
-    data={"joint_name":{"type":[1.23,4.56,7.89]}, ...}
+
+Typically you just want to send a "set" command:
+    puppetry.sendSet(data)
+
+The 'set' data is a dictionary with the following format:
+    data={"inverse_kinematics":{"joint_name":{"type":[1.23,4.56,7.89] ,...} ,...},
+          "joint_state":{"joint_name":{"type":[1.23,4.56,7.89] ,...} ,...}}
 Where:
-    joint_name = string recognized by LLVOAvatar::getJoint(const std::string&),
+    'inverse_kinematics' for specifying avatar-frame target transforms
+    'joint_state' for specifying parent-frame joint transforms
+        alternatively can use terse format: 'i' instead of 'inverse_kinematics' and 'j' instead of 'joint_state'
+
+    'joint_name' = string recognized by LLVOAvatar::getJoint(const std::string&),
         e.g. something like: "mWristLeft"
-    type = "rot" | "pos" | "scale"
+
+    'type' = "rotation" | "position" | "scale"
+        alternatively can use terse format: 'r', 'p', and 's'
+
     type's value = array of three floats (e.g. [x,y,z])
-Multiple joints can be combined into the same dictionary.
-
-Note: When you test this script at the command line it will block
-because the leap.py framework is waiting for the initial message
-from the viewer.  To unblock the system paste the following
-string into the script's stdin:
-
-119:{'data':{'command':'18ce5015-b651-1d2e-2470-0de841fd3635','features':{}},'pump':'54481a53-c41f-4fc2-606e-516daed03636'}
-
-Also, for more readable text with newlines between messages
-uncomment the print("") line in the main loop below.
 """
 
 import logging

--- a/puppetry/examples/head_nod.py
+++ b/puppetry/examples/head_nod.py
@@ -6,25 +6,27 @@ head_nod.py -- use Puppetry to update head's local orientation
 
 Run this script via viewer menu...
     Advanced --> Puppetry --> Launch LEAP plug-in...
+
 This script uses the LEAP framework for sending messages to the viewer.
-The joint data is a dictionary with the following format:
-    data={"joint_name":{"type":[1.23,4.56,7.89]}, ...}
+
+Typically you just want to send a "set" command:
+    puppetry.sendSet(data)
+
+The 'set' data is a dictionary with the following format:
+    data={"inverse_kinematics":{"joint_name":{"type":[1.23,4.56,7.89] ,...} ,...},
+          "joint_state":{"joint_name":{"type":[1.23,4.56,7.89] ,...} ,...}}
 Where:
-    joint_name = string recognized by LLVOAvatar::getJoint(const std::string&),
+    'inverse_kinematics' for specifying avatar-frame target transforms
+    'joint_state' for specifying parent-frame joint transforms
+        alternatively can use terse format: 'i' instead of 'inverse_kinematics' and 'j' instead of 'joint_state'
+
+    'joint_name' = string recognized by LLVOAvatar::getJoint(const std::string&),
         e.g. something like: "mWristLeft"
-    type = "rot" | "pos" | "scale"
+
+    'type' = "rotation" | "position" | "scale"
+        alternatively can use terse format: 'r', 'p', and 's'
+
     type's value = array of three floats (e.g. [x,y,z])
-Multiple joints can be combined into the same dictionary.
-
-Note: When you test this script at the command line it will block
-because the leap.py framework is waiting for the initial message
-from the viewer.  To unblock the system paste the following
-string into the script's stdin:
-
-119:{'data':{'command':'18ce5015-b651-1d2e-2470-0de841fd3635','features':{}},'pump':'54481a53-c41f-4fc2-606e-516daed03636'}
-
-Also, for more readable text with newlines between messages
-uncomment the print("") line in the main loop below.
 """
 
 import math
@@ -106,7 +108,7 @@ def computeData(time_step):
     # assemble the message
     packed_rot = puppetry.packedQuaternionFromEulerAngles(tilt, nod, turn)
     data = {
-        'mHead':{'local_rot': packed_rot}
+        'mHead':{'rotation': packed_rot}
     }
     return data
 

--- a/puppetry/examples/minimum_example.py
+++ b/puppetry/examples/minimum_example.py
@@ -7,15 +7,29 @@ import eventlet
 import puppetry
 
 """
-Note: When you debug this script at the command line it will block
-because the leap.py framework is waiting for the initial message
-from the viewer.  To unblock the system paste the following
-string into the script's stdin:
+Run this script via viewer menu...
+    Advanced --> Puppetry --> Launch LEAP plug-in...
 
-119:{'data':{'command':'18ce5015-b651-1d2e-2470-0de841fd3635','features':{}},'pump':'54481a53-c41f-4fc2-606e-516daed03636'}
+This script uses the LEAP framework for sending messages to the viewer.
 
-Also when debugging, for more readable text with newlines between
-messages uncomment the print("") line in the main loop below.
+Typically you just want to send a "set" command:
+    puppetry.sendSet(data)
+
+The 'set' data is a dictionary with the following format:
+    data={"inverse_kinematics":{"joint_name":{"type":[1.23,4.56,7.89] ,...} ,...},
+          "joint_state":{"joint_name":{"type":[1.23,4.56,7.89] ,...} ,...}}
+Where:
+    'inverse_kinematics' for specifying avatar-frame target transforms
+    'joint_state' for specifying parent-frame joint transforms
+        alternatively can use terse format: 'i' instead of 'inverse_kinematics' and 'j' instead of 'joint_state'
+
+    'joint_name' = string recognized by LLVOAvatar::getJoint(const std::string&),
+        e.g. something like: "mWristLeft"
+
+    'type' = "rotation" | "position" | "scale"
+        alternatively can use terse format: 'r', 'p', and 's'
+
+    type's value = array of three floats (e.g. [x,y,z])
 """
 
 update_period = 0.1

--- a/puppetry/examples/puppet_poser.py
+++ b/puppetry/examples/puppet_poser.py
@@ -3,34 +3,29 @@
 Simple LEAP script to read a data file and send puppetry data.
 The file is re-read every cycle, so can be live edited to see changes
 
+Run this script via viewer menu...
+    Advanced --> Puppetry --> Launch LEAP plug-in...
+
 This script uses the LEAP framework for sending messages to the viewer.
-Tell the viewer to launch it with the following option:
-    --leap "python /path/to/this/script/this_script.py"
-The viewer will start this script in a side process and will
-read messages from its stdout.
 
-The joint data is a dictionary with the following format:
-    data={"joint_name":{"type":[1.23,4.56,7.89]}, ...}
+Typically you just want to send a "set" command:
+    puppetry.sendSet(data)
+
+The 'set' data is a dictionary with the following format:
+    data={"inverse_kinematics":{"joint_name":{"type":[1.23,4.56,7.89] ,...} ,...},
+          "joint_state":{"joint_name":{"type":[1.23,4.56,7.89] ,...} ,...}}
 Where:
-    joint_name = string recognized by viewer routine
-    LLVOAvatar::getJoint(const std::string&),
+    'inverse_kinematics' for specifying avatar-frame target transforms
+    'joint_state' for specifying parent-frame joint transforms
+        alternatively can use terse format: 'i' instead of 'inverse_kinematics' and 'j' instead of 'joint_state'
+
+    'joint_name' = string recognized by LLVOAvatar::getJoint(const std::string&),
         e.g. something like: "mWristLeft"
-    type = "local_rot" | "rot" | "pos" | "scale"
+
+    'type' = "rotation" | "position" | "scale"
+        alternatively can use terse format: 'r', 'p', and 's'
+
     type's value = array of three floats (e.g. [x,y,z])
-Multiple joints can be combined into the same dictionary.
-
-Notes about debugging at the command line:
-
-When you test this script at the command line it will block
-because the leap.py framework is waiting for the initial message
-from the viewer.  To unblock the system paste the following
-string into the script's stdin:
-
-119:{'data':{'command':'18ce5015-b651-1d2e-2470-0de841fd3635','features':{}}, \
-        'pump':'54481a53-c41f-4fc2-606e-516daed03636'}
-
-Also, for more readable text with newlines between messages
-uncomment the print("") line in the main loop below.
 """
 
 import copy

--- a/puppetry/webcam/head_webcam.py
+++ b/puppetry/webcam/head_webcam.py
@@ -177,7 +177,7 @@ class Expression:
         pitch = float(self.face_rot_vec[0][0] + 3.2)
         roll = float(self.face_rot_vec[2][0] * -1.0)
         packed_quaternion = puppetry.packedQuaternionFromEulerAngles(yaw, pitch, roll)
-        data = {"mHead": {"rot": packed_quaternion}}
+        data = {"mHead": {"rotation": packed_quaternion}}
 
         #TODO: scale translation into the model space and apply as the mHead effector target
         #Use the rest of the model points in relation to the plane of the face to

--- a/puppetry/webcam/webcam_puppetry.py
+++ b/puppetry/webcam/webcam_puppetry.py
@@ -272,7 +272,7 @@ class Expression:
                     radians(deg_rot[0]), radians(deg_rot[1]), radians(deg_rot[2]) )
 
         if puppetry.part_active('head'):                        #Add head rotation data to the output stream
-            add_state("mHead","rot", packed_quaternion, output)
+            add_state("mHead","rotation", packed_quaternion, output)
 
         return self.head_rot_ea
 


### PR DESCRIPTION
This PR finally pulls the last of the example scripts into the new LEAP Puppetry API.

Adding arms_and_pelvis.py example just to show moveable-pelvis and IK working well together.