### PR TITLE
Add dependabot to CLA allowlist

### DIFF
--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -23,3 +23,4 @@ jobs:
           path-to-signatures: signatures.json
           remote-organization-name: secondlife
           remote-repository-name: cla-signatures
+          allowlist: dependabot[bot]


### PR DESCRIPTION
Add dependabot to the CLA assistant bot allow list to avoid issues like in #12.