### PR TITLE
Fix pre-commit CI/CD

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     - id: mixed-line-ending
     - id: trailing-whitespace
 - repo: https://github.com/pycqa/isort
-  rev: 5.10.1
+  rev: 5.12.0
   hooks:
     - id: isort
       args: [--line-length=120]


### PR DESCRIPTION
Bump isort version in pre-commit-config to a version that fixes an incompatibility with the latest poetry version.

https://github.com/PyCQA/isort/releases/tag/5.11.5