### PR TITLE
SL-18330: Use new standalone llsd module instead of llbase.llsd.

### DIFF
--- a/leap/__init__.py
+++ b/leap/__init__.py
@@ -43,7 +43,7 @@ import platform
 import re
 import sys
 
-from llbase import llsd
+import llsd
 
 os.environ['EVENTLET_THREADPOOL_SIZE'] = '2'
 # On Mac with Python 3.9, we must use the poll hub rather than the

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ console_scripts =
 [options.extras_require]
 puppetry =
     PyGLM
-    llbase
+    llsd
 opencv =
     dlib
     mediapipe


### PR DESCRIPTION
(Successor to https://github.com/secondlife/leap/pull/14)

Ongoing development has moved to [standalone llsd](https://github.com/secondlife/python-llsd) instead of llbase.llsd. In particular, https://github.com/secondlife/python-llsd/pull/4 has greatly improved ability to correctly parse the stdin stream from the viewer.