### PR TITLE
fix typo: req_id --> reqid

### DIFF
--- a/puppetry/__init__.py
+++ b/puppetry/__init__.py
@@ -184,8 +184,8 @@ def sendSet(data):
 
     if _running:
         if isinstance(data, dict):
-            req_id = get_next_request_id()
-            msg = { 'command':'set', 'data':data, 'reqid':req_id }
+            reqid = get_next_request_id()
+            msg = { 'command':'set', 'data':data, 'reqid':reqid }
 
             if 'reqid' in data:
                 if data['reqid'] == 'auto': #HACK: Echo request ID into message.


### PR DESCRIPTION
This PR fixes a simple typo that causes puppetry scripts to crash.